### PR TITLE
Change ,,Continue as guest" to link-style on login page

### DIFF
--- a/gamelibrary/main/templates/login.html
+++ b/gamelibrary/main/templates/login.html
@@ -36,9 +36,8 @@
         <button class="button1" type="submit">Log In</button>
     </form>
 
-    <div class="guest-login" style="margin-top: 10px;">
-        <a href="{% url 'library' %}" class="button1" style="display: inline-block;">Continue as Guest</a>
-    </div>
+    <p style="margin-top: 10px;">
+        <a href="{% url 'library' %}" class="guest-link">Continue as guest</a>
 
     <p>Don't have account? <a href="{% url 'register' %}">Sign up here</a></p>
 </div>


### PR DESCRIPTION
Turned the ,,Continue as guest" button into a text link to better match the login page design. It still redirects to the library view, only the visual style is changed. No backhend logic is modified.